### PR TITLE
Adding MetaImage support, including compression, to fiji's IO 

### DIFF
--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -390,6 +390,16 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
             return tryPlugIn("edu.utexas.clm.archipelago.Fiji_Archipelago", path);
         }
 
+	// Roman Grothausmann: read metaimages (ITK) with MetaImage_Reader
+	if (name.endsWith(".mhd")) {
+	    //ij.IJ.log("Found MHD, trying MetaImage_Reader...");
+	    return tryPlugIn("io.MetaImage_Reader", path);
+	}
+	if (name.endsWith(".mha")) {
+	    //ij.IJ.log("Found MHA, trying MetaImage_Reader...");
+	    return tryPlugIn("io.MetaImage_Reader", path);
+	}
+
         //Samuel Inverso: open raw files with raw file plugin 
         if (name.endsWith(".raw"))
         {

--- a/src/main/java/io/MetaImage_Reader.java
+++ b/src/main/java/io/MetaImage_Reader.java
@@ -41,7 +41,7 @@ FITNESS FOR ANY PARTICULAR PURPOSE.
 //02: make mha read correctly: 
 //    1. only feed header to Propoerties.load() because load() interprets unicode escape sequences which are likely to occure in data part
 //    2. only feed data to InflaterInputStream, therefore skip header on the exact byte count
-//03: support for not compressed mha, clean up, optimization, ByteOrder fitting ITK
+//03: support for not compressed mha, clean up, optimization, ByteOrder fitting ITK, 64bit float support
 
 import java.io.*;
 import java.util.*;
@@ -322,6 +322,7 @@ public class MetaImage_Reader implements PlugIn {
             else if (strElementType.equals("MET_INT"))    { fi.fileType = FileInfo.GRAY32_INT;      }
             else if (strElementType.equals("MET_UINT"))   { fi.fileType = FileInfo.GRAY32_UNSIGNED; }
             else if (strElementType.equals("MET_FLOAT"))  { fi.fileType = FileInfo.GRAY32_FLOAT;    }
+            else if (strElementType.equals("MET_DOUBLE")) { fi.fileType = FileInfo.GRAY64_FLOAT;    }
             else {
                 throw new IOException(
                     "Unsupported element type: " +
@@ -345,8 +346,10 @@ public class MetaImage_Reader implements PlugIn {
         }
 
         if (strElementDataFile != null && strElementDataFile.length() > 0) {
-          if (strElementDataFile.equals("LOCAL"))
+            if (strElementDataFile.equals("LOCAL")){
               fi.fileName = headerName;
+                //IJ.log("Detected local data storage!" + fi.fileName);
+                }
             else
               fi.fileName = strElementDataFile;
         }

--- a/src/main/java/io/MetaImage_Reader.java
+++ b/src/main/java/io/MetaImage_Reader.java
@@ -1,0 +1,322 @@
+/**
+    MetaImage reader plugin for ImageJ.
+
+    This plugin reads MetaImage text-based tagged format files.
+
+    Author: Kang Li (kangli AT cs.cmu.edu)
+
+    Installation:
+      Download MetaImage_Reader_Writer.jar to the plugins folder, or subfolder.
+      Restart ImageJ, and there will be new File/Import/MetaImage... and
+      File/Save As/MetaImage... commands.
+
+    History:
+      2007/04/07: First version
+      2008/07/25: Fixed two bugs (thanks to Jon Rohrer)
+
+    References:
+      MetaIO Documentation (http://www.itk.org/Wiki/MetaIO/Documentation)
+*/
+
+/**
+Copyright (C) 2007-2008 Kang Li. All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+without fee is hereby granted,  provided that this entire notice  is included
+in all copies of any software which is or includes a copy or modification  of
+this software  and in  all copies  of the  supporting documentation  for such
+software. Any for profit use of this software is expressly forbidden  without
+first obtaining the explicit consent of the author.
+
+THIS  SOFTWARE IS  BEING PROVIDED  "AS IS",  WITHOUT ANY  EXPRESS OR  IMPLIED
+WARRANTY.  IN PARTICULAR,  THE AUTHOR  DOES NOT  MAKE ANY  REPRESENTATION OR
+WARRANTY OF ANY KIND CONCERNING  THE MERCHANTABILITY OF THIS SOFTWARE  OR ITS
+FITNESS FOR ANY PARTICULAR PURPOSE.
+*/
+
+import java.io.*;
+import java.util.*;
+import ij.*;
+import ij.plugin.*;
+import ij.process.*;
+import ij.io.*;
+
+public class MetaImage_Reader implements PlugIn {
+
+    public boolean littleEndian = false;
+
+    public void run(String arg) {
+        OpenDialog od = new OpenDialog("Open MetaImage...", arg);
+        String dir = od.getDirectory();
+        String baseName = od.getFileName();
+        if (baseName == null || baseName.length() == 0)
+            return;
+        int baseLength = baseName.length();
+        String lowerBaseName = baseName.toLowerCase();
+        boolean mhd = lowerBaseName.endsWith(".mhd");
+        boolean mha = lowerBaseName.endsWith(".mha");
+        boolean raw = lowerBaseName.endsWith(".raw");
+        String headerName;
+        if (mha || mhd) {
+            headerName = baseName;
+            baseName   = baseName.substring(0, baseLength - 4);
+        }
+        else {
+            baseName   = baseName.substring(0, baseLength - 4);
+            headerName = baseName + ".mhd";
+        }
+        IJ.showStatus("Opening " + headerName + "...");
+        ImagePlus imp = load(dir, baseName, headerName, mha);
+        if (imp != null)
+            imp.show();
+        IJ.showStatus(baseName + " opened");
+    }
+
+
+    private ImagePlus load(String  dir,
+                           String  baseName,
+                           String  headerName,
+                           boolean local)
+    {
+        ImagePlus impOut = null;
+        try {
+            FileInfo fi = readHeader(dir, baseName, headerName, local);
+            if (fi.fileName.equals("LIST")) {
+                // Loads a sequence of files.
+                BufferedReader in = new BufferedReader(new FileReader(dir + headerName));
+                ImageStack stackOut = new ImageStack(fi.width, fi.height);
+                boolean autoOffset = (fi.longOffset < 0);
+                boolean fileNamesBegin = false;
+                String line = in.readLine();
+                int index = 0, numImages = fi.nImages;
+                while (null != line) {
+                    line = line.trim();
+                    if (fileNamesBegin) {
+                        String[] parts = line.split("\\s+");
+                        for (int i = 0; i < parts.length; ++i) {
+                            // Adjust the fields of FileInfo.
+                            fi.nImages = 1;
+                            fi.fileName = parts[i];
+                            if (autoOffset)
+                                fi.longOffset = getOffset(fi);
+                            IJ.showStatus("Reading " + fi.fileName + "...");
+                            FileOpener opener = new FileOpener(fi);
+                            ImagePlus imp = opener.open(false);
+                            ImageStack stack = imp.getStack();
+                            for (int j = 1; j <= stack.getSize(); ++j) {
+                                // Load the first image only even if there are more.
+                                ImageProcessor ip = stack.getProcessor(j);
+                                stackOut.addSlice(fi.fileName, ip);
+                                break;
+                            } // for j
+                            if (++index >= numImages)
+                                break;
+                        } // for i
+                    }
+                    else {
+                        if (line.startsWith("ElementDataFile"))
+                            fileNamesBegin = true;
+                    }
+                    if (index >= numImages)
+                        break;
+                    line = in.readLine();
+                }
+                impOut = new ImagePlus(baseName, stackOut);
+                impOut.setStack(null, stackOut);
+            }
+            else if (fi.fileName.indexOf('%') >= 0) {
+              String[] parts = fi.fileName.split("\\s+");
+              int imin = 1;
+              int imax = fi.nImages;
+              int step = 1;
+              if (parts.length > 1) {
+                imin = Integer.parseInt(parts[1]);
+                if (parts.length > 2) {
+                  imax = Integer.parseInt(parts[2]);
+                  if (parts.length > 3)
+                    step = Integer.parseInt(parts[3]);
+                }
+              }
+              boolean autoOffset = (fi.longOffset < 0);
+              ImageStack stackOut = new ImageStack(fi.width, fi.height);
+              int index = 0, numImages = fi.nImages;
+              fi.nImages = 1;
+              for (int i = imin; i <= imax; i += step) {
+                Formatter formatter = new Formatter();
+                formatter.format(parts[0], i);
+                fi.fileName = formatter.toString();
+                if (autoOffset)
+                  fi.longOffset = getOffset(fi);
+                IJ.showStatus("Reading " + fi.fileName + "...");
+                    FileOpener opener = new FileOpener(fi);
+                    ImagePlus imp = opener.open(false);
+                    ImageStack stack = imp.getStack();
+                    for (int j = 1; j <= stack.getSize(); ++j) {
+                        // Load the first image only even if there are more.
+                        ImageProcessor ip = stack.getProcessor(j);
+                        stackOut.addSlice(fi.fileName, ip);
+                        break;
+                    } // for j
+                    if (++index >= numImages)
+            break;
+              } // for i
+              impOut = new ImagePlus(baseName, stackOut);
+                impOut.setStack(null, stackOut);
+            }
+            else {
+                if (fi.longOffset < 0)
+                    fi.longOffset = getOffset(fi);
+                IJ.showStatus("Reading " + fi.fileName + "...");
+                FileOpener opener = new FileOpener(fi);
+                impOut = opener.open(false);
+            }
+        }
+        catch (IOException e) {
+            IJ.error("MetaImage Reader: " + e.getMessage());
+        }
+        catch (NumberFormatException e) {
+            IJ.error("MetaImage Reader: " + e.getMessage());
+        }
+        return impOut;
+    }
+
+
+    private FileInfo readHeader(String  dir,
+                                String  baseName,
+                                String  headerName,
+                                boolean local) throws IOException, NumberFormatException
+    {
+        FileInfo fi = new FileInfo();
+        fi.directory  = dir;
+        fi.fileFormat = FileInfo.RAW;
+
+        Properties p = new Properties();
+        p.load(new FileInputStream(dir + headerName));
+        String strObjectType = p.getProperty("ObjectType");
+        String strNDims = p.getProperty("NDims");
+        String strDimSize = p.getProperty("DimSize");
+        String strElementSize = p.getProperty("ElementSize");
+        String strElementDataFile = p.getProperty("ElementDataFile");
+        String strElementByteOrderMSB = p.getProperty("ElementByteOrderMSB");
+        if (null == strElementByteOrderMSB)
+          strElementByteOrderMSB = p.getProperty("BinaryDataByteOrderMSB");
+        String strElementNumberOfChannels = p.getProperty("ElementNumberOfChannels", "1");
+        String strElementType = p.getProperty("ElementType", "MET_NONE");
+        String strHeaderSize = p.getProperty("HeaderSize", "0");
+
+        if (strObjectType == null || !strObjectType.equalsIgnoreCase("Image"))
+            throw new IOException("The specified file does not contain an image.");
+        int ndims = Integer.parseInt(strNDims);
+        if (strDimSize == null)
+            throw new IOException("The image dimension size is unspecified.");
+        else {
+            String[] parts = strDimSize.split("\\s+");
+            if (parts.length < ndims)
+                throw new IOException("Invalid dimension size.");
+            if (ndims > 1) {
+                fi.width = Integer.parseInt(parts[0]);
+                fi.height = Integer.parseInt(parts[1]);
+                fi.nImages = 1;
+                if (ndims > 2) {
+                    for (int i = ndims - 1; i >= 2; --i)
+                        fi.nImages *= Integer.parseInt(parts[i]);
+                }
+            }
+            else {
+                throw new IOException("Unsupported number of dimensions.");
+            }
+        }
+        if (strElementSize != null) {
+            String[] parts = strElementSize.split("\\s+");
+            if (parts.length > 0)
+                fi.pixelWidth  = Double.parseDouble(parts[0]);
+            if (parts.length > 1)
+                fi.pixelHeight = Double.parseDouble(parts[1]);
+            if (parts.length > 2)
+                fi.pixelDepth  = Double.parseDouble(parts[2]);
+        }
+        int numChannels = Integer.parseInt(strElementNumberOfChannels);
+        if (numChannels == 1) {
+            if (strElementType.equals("MET_UCHAR"))       { fi.fileType = FileInfo.GRAY8;           }
+            else if (strElementType.equals("MET_SHORT"))  { fi.fileType = FileInfo.GRAY16_SIGNED;   }
+            else if (strElementType.equals("MET_USHORT")) { fi.fileType = FileInfo.GRAY16_UNSIGNED; }
+            else if (strElementType.equals("MET_INT"))    { fi.fileType = FileInfo.GRAY32_INT;      }
+            else if (strElementType.equals("MET_UINT"))   { fi.fileType = FileInfo.GRAY32_UNSIGNED; }
+            else if (strElementType.equals("MET_FLOAT"))  { fi.fileType = FileInfo.GRAY32_FLOAT;    }
+            else {
+                throw new IOException(
+                    "Unsupported element type: " +
+                    strElementType +
+                    ".");
+            }
+        }
+        else if (numChannels == 3) {
+            if (strElementType.equals("MET_UCHAR_ARRAY")) fi.fileType = FileInfo.RGB;
+            else if (strElementType.equals("MET_USHORT_ARRAY"))
+                fi.fileType = FileInfo.RGB48;
+            else {
+                throw new IOException(
+                    "Unsupported element type: " +
+                    strElementType +
+                    ".");
+            }
+        }
+        else {
+            throw new IOException("Unsupported number of channels.");
+        }
+
+        if (strElementDataFile != null && strElementDataFile.length() > 0) {
+          if (strElementDataFile.equals("LOCAL"))
+              fi.fileName = headerName;
+            else
+              fi.fileName = strElementDataFile;
+        }
+        else {
+            if (!local)
+              fi.fileName = baseName + ".raw";
+            else
+              fi.fileName = headerName;
+        }
+
+        if (strElementByteOrderMSB != null) {
+            if (strElementByteOrderMSB.length() > 0
+                && (strElementByteOrderMSB.charAt(0) == 'T' ||
+                    strElementByteOrderMSB.charAt(0) == 't' ||
+                    strElementByteOrderMSB.charAt(0) == '1')) 
+                fi.intelByteOrder = false;
+            else
+                fi.intelByteOrder = true;
+        }
+
+        fi.longOffset = (long)Integer.parseInt(strHeaderSize);
+
+        return fi;
+    }
+
+
+    private int getBytesPerPixel(FileInfo fi) {
+        int bpp = 0;
+        switch (fi.fileType) {
+        case FileInfo.GRAY8:           return  1;
+        case FileInfo.GRAY16_SIGNED:   return  2;
+        case FileInfo.GRAY16_UNSIGNED: return  2;
+        case FileInfo.GRAY32_INT:      return  4;
+        case FileInfo.GRAY32_UNSIGNED: return  4;
+        case FileInfo.GRAY32_FLOAT:    return  4;
+        case FileInfo.RGB:             return 24;
+        case FileInfo.RGB48:           return 48;
+        default:
+            break;
+        }
+        return bpp;
+    }
+
+
+    private long getOffset(FileInfo fi) {
+        // Automatically calculate the header size.
+        int bpp = getBytesPerPixel(fi);
+        long dataBytes = bpp * fi.width * fi.height * fi.nImages;
+        File file = new File(fi.directory + fi.fileName);
+        return file.length() - dataBytes;
+    }
+}

--- a/src/main/java/io/MetaImage_Writer.java
+++ b/src/main/java/io/MetaImage_Writer.java
@@ -1,0 +1,173 @@
+/**
+    MetaImage writer plugin for ImageJ.
+
+    This plugin writes MetaImage text-based tagged format files.
+
+    Author: Kang Li (kangli AT cs.cmu.edu)
+
+    Installation:
+      Download MetaImage_Reader_Writer.jar to the plugins folder, or subfolder.
+      Restart ImageJ, and there will be new File/Import/MetaImage... and
+      File/Save As/MetaImage... commands.
+
+    History:
+      2007/04/07: First version
+
+    References:
+      MetaIO Documentation (http://www.itk.org/Wiki/MetaIO/Documentation)
+*/
+
+/**
+Copyright (C) 2007-2008 Kang Li. All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+without fee is hereby granted,  provided that this entire notice  is included
+in all copies of any software which is or includes a copy or modification  of
+this software  and in  all copies  of the  supporting documentation  for such
+software. Any for profit use of this software is expressly forbidden  without
+first obtaining the explicit consent of the author.
+
+THIS  SOFTWARE IS  BEING PROVIDED  "AS IS",  WITHOUT ANY  EXPRESS OR  IMPLIED
+WARRANTY.  IN PARTICULAR,  THE AUTHOR  DOES NOT  MAKE ANY  REPRESENTATION OR
+WARRANTY OF ANY KIND CONCERNING  THE MERCHANTABILITY OF THIS SOFTWARE  OR ITS
+FITNESS FOR ANY PARTICULAR PURPOSE.
+*/
+
+import java.io.*;
+import java.awt.*;
+import ij.*;
+import ij.gui.*;
+import ij.io.*;
+import ij.plugin.*;
+import ij.process.*;
+import ij.measure.Calibration;
+
+//  This plugin saves MetaImage format files.
+//  It appends the '.mhd' and '.raw' suffixes to the header and data files, respectively.
+//
+
+public final class MetaImage_Writer implements PlugIn {
+
+    public void run(String arg) {
+        ImagePlus imp = WindowManager.getCurrentImage();
+        if (imp == null) {
+            IJ.noImage();
+            return;
+        }
+        if (imp.getCalibration().isSigned16Bit() && IJ.versionLessThan("1.34e")) {
+            IJ.error("MetaImage Reader: Please upgrade to ImageJ v1.34e or later.");
+            return;
+        }
+        String dir = "", baseName = "";
+        if (arg == null || arg.length() == 0) {
+            SaveDialog sd = new SaveDialog(
+              "Save as MetaImage", imp.getTitle(), ".mhd");
+            dir = sd.getDirectory();
+            baseName = sd.getFileName();
+        }
+        else {
+            File file = new File(arg);
+            if (file.isDirectory()) {
+                dir = arg;
+                baseName = imp.getTitle();
+            }
+            else {
+                dir = file.getParent();
+                baseName = file.getName();
+            }
+        }
+
+        if (baseName == null || baseName.length() == 0)
+            return;
+
+        int baseLength = baseName.length();
+        String lowerBaseName = baseName.toLowerCase();
+        if (lowerBaseName.endsWith(".mhd") || lowerBaseName.endsWith(".mda"))
+            baseName = baseName.substring(0, baseLength - 4);
+        save(imp, dir, baseName);
+        IJ.showStatus(baseName + " saved");
+    }
+
+
+    private void save(ImagePlus imp, String dir, String baseName) {
+
+        if (!dir.endsWith(File.separator) && dir.length() > 0)
+            dir += File.separator;
+
+        try {
+            // Save header file.
+            String headerName = baseName + ".mhd";
+            String dataName = baseName + ".raw";
+            IJ.showStatus("Saving " + headerName + "...");
+            if (writeHeader(imp, dir + headerName, dataName)) {
+                // Save data file.
+                IJ.showStatus("Writing " + dataName + "...");
+                if (imp.getStackSize() > 1)
+                    new FileSaver(imp).saveAsRawStack(dir + dataName);
+                else
+                    new FileSaver(imp).saveAsRaw(dir + dataName);
+            }
+        }
+        catch (IOException e) {
+            IJ.error("MetaImage_Writer: " + e.getMessage());
+        }
+    }
+
+
+    private boolean writeHeader(ImagePlus imp, String path, String dataFile)
+        throws IOException
+    {
+        FileInfo fi = imp.getFileInfo();
+        String numChannels = "1", type = "MET_NONE";
+
+        switch (fi.fileType) {
+        case FileInfo.COLOR8:          type = "MET_UCHAR";  break;
+        case FileInfo.GRAY8:           type = "MET_UCHAR";  break;
+        case FileInfo.GRAY16_SIGNED:   type = "MET_SHORT";  break;
+        case FileInfo.GRAY16_UNSIGNED: type = "MET_USHORT"; break;
+        case FileInfo.GRAY32_INT:      type = "MET_INT";    break;
+        case FileInfo.GRAY32_UNSIGNED: type = "MET_UINT";   break;
+        case FileInfo.GRAY32_FLOAT:    type = "MET_FLOAT";  break;
+        case FileInfo.RGB:
+            type = "MET_UCHAR_ARRAY";  numChannels = "3";
+            break;
+        case FileInfo.RGB48:
+            type = "MET_USHORT_ARRAY"; numChannels = "3";
+            break;
+        default:
+            throw new IOException(
+                "Unsupported data format.");
+        }
+
+        FileOutputStream file = new FileOutputStream(path);
+        PrintStream stream = new PrintStream(file);
+        
+        int ndims = (imp.getStackSize() > 1) ? 3 : 2;
+
+        stream.println("ObjectType = Image");
+        if (ndims == 3)
+            stream.println("NDims = 3");
+        else
+            stream.println("NDims = 2");
+        stream.println("BinaryData = True");
+        if (fi.intelByteOrder)
+            stream.println("BinaryDataByteOrderMSB = True");
+        if (ndims == 3) {
+            stream.println("DimSize = " + fi.width + " " + fi.height + " " + fi.nImages);
+            stream.println("ElementSize = " + fi.pixelWidth + " " + fi.pixelHeight + " " + fi.pixelDepth);
+        }
+        else {
+            stream.println("DimSize = " + fi.width + " " + fi.height);
+            stream.println("ElementSize = " + fi.pixelWidth + " " + fi.pixelHeight);
+        }
+        if (numChannels != "1")
+            stream.println("ElementNumberOfChannels = " + numChannels);
+        stream.println("ElementType = " + type);
+        stream.println("ElementDataFile = " + dataFile);
+
+        stream.close();
+        file.close();
+
+        return true;
+    }
+}

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -1,3 +1,8 @@
+# Author: Roman Grothausmann
+File>Save As, "MHD/MHA ...", io.MetaImage_Writer
+File>Save As, "MHD/MHA compressed ...", io.MetaImage_CWriter
+File>Import, "MHD/MHA...", io.MetaImage_Reader
+
 # Author: Stephan Saalfeld
 File>Save As, "DF3 ...", io.Save_DF3
 File>Import, "DF3...", io.Open_DF3


### PR DESCRIPTION
This contribution is based on Kang Li's MetaImage plugin. I extended it to also support compressed MetaImages. Now as a fork of fiji/IO as suggested by Curtis (http://imagej.1557.x6.nabble.com/Re-ITK-users-Extensions-to-the-MetaImage-MHDs-IO-plugin-to-support-compression-and-MHAs-td5009027.html)
