### PR TITLE
Preserve the ImageWindow's subtitle "Label" property

### DIFF
--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -80,6 +80,9 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 		// also copy the Show Info field over if it exists
 		if (imp.getProperty("Info") != null)
 			setProperty("Info", imp.getProperty("Info"));
+		// also copy the subtitle ("Label") field over if it exists
+		if (imp.getProperty("Label") != null)
+		    setProperty("Label", imp.getProperty("Label"));
 		// copy over the FileInfo
 		setFileInfo(imp.getOriginalFileInfo());
 		// copy dimensions


### PR DESCRIPTION
Preserve the ImageWindow's subtitle "Label" property when reading from formats that subclass ImagePlus.

This makes files opened directly from a plugin or indirectly from HandleExtraFileTypes behave the same.

This [mailing list thread](http://imagej.1557.x6.nabble.com/HandleExtraFileTypes-does-not-preserve-subtitle-quot-Label-quot-property-td5011960.html) has further detail.
