### PR TITLE
MRC: fix mixed up coordinate system

### DIFF
--- a/src/main/java/sc/fiji/io/Open_MRC_Leginon.java
+++ b/src/main/java/sc/fiji/io/Open_MRC_Leginon.java
@@ -231,6 +231,9 @@ public class Open_MRC_Leginon extends ImagePlus implements PlugIn {
 		setStack(imp.getTitle(),stack);
 		setCalibration(imp.getCalibration());
 
+		// NB: Per definition, the MRC coordinate system is located at the lower
+		// left corner in contrast to ImageJ's default. To fix that, flip the images
+		// vertically after reading.
 		for (int i=1; i<=stack.getSize(); ++i) {
 				ImageProcessor tempImageProcessor = stack.getProcessor(i);
 				tempImageProcessor.flipVertical();

--- a/src/main/java/sc/fiji/io/Open_MRC_Leginon.java
+++ b/src/main/java/sc/fiji/io/Open_MRC_Leginon.java
@@ -159,6 +159,7 @@ import ij.io.FileInfo;
 import ij.io.FileOpener;
 import ij.io.OpenDialog;
 import ij.plugin.PlugIn;
+import ij.process.ImageProcessor;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -229,6 +230,12 @@ public class Open_MRC_Leginon extends ImagePlus implements PlugIn {
 		ImageStack stack = imp.getStack();
 		setStack(imp.getTitle(),stack);
 		setCalibration(imp.getCalibration());
+
+		for (int i=1; i<=stack.getSize(); ++i) {
+				ImageProcessor tempImageProcessor = stack.getProcessor(i);
+				tempImageProcessor.flipVertical();
+		}
+
 		Object obinfo = imp.getProperty("Info");
 		if (null != obinfo) setProperty("Info", obinfo);
 		setFileInfo(imp.getOriginalFileInfo());


### PR DESCRIPTION
Per definition, the MRC coordinate system is located at the lower left corner in contrast to ImageJ's default. This PR is a quick fix that flips the images after reading (otherwise the user would have to do it).

A better fix would be to fill up the arrays that back ImageProcessors the way MRC intends images to be read. This would very likely result in code duplication from `ij.io.FileOpener` (imho).
