### PR TITLE
make MetaImage_Reader.load() public

### DIFF
--- a/src/main/java/sc/fiji/io/MetaImage_Reader.java
+++ b/src/main/java/sc/fiji/io/MetaImage_Reader.java
@@ -132,7 +132,7 @@ public class MetaImage_Reader implements PlugIn {
     }
 
 
-    private ImagePlus load(String  dir,
+    public ImagePlus load(String  dir,
                            String  baseName,
                            String  headerName,
                            boolean local)


### PR DESCRIPTION
Hi all,

can we please make that method public in order to be able to read mha files in an easy way?

You find a related discussion on the Image.sc forum:
https://forum.image.sc/t/how-can-i-open-and-read-an-mha-file-from-within-a-maven-project/33361

Thanks!

Cheers,
Robert