### PR TITLE
triggering of org.scijava.ui.dnd.DragAndDrop* mechanism

### DIFF
--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -37,6 +37,8 @@ import java.util.zip.GZIPInputStream;
 import org.scijava.Context;
 import org.scijava.io.IOService;
 import org.scijava.ui.UIService;
+import org.scijava.ui.dnd.DragAndDropService;
+import org.scijava.display.DisplayService;
 
 // Plugin to handle file types which are not implemented
 // directly in ImageJ through io.Opener
@@ -543,6 +545,13 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 			final Object ctx = IJ.runPlugIn("org.scijava.Context", "");
 			if (ctx instanceof Context) {
 				final Context context = (Context) ctx;
+				final DragAndDropService dndService = context.getService(DragAndDropService.class);
+				final DisplayService dsService = context.getService(DisplayService.class);
+				if ( dndService != null && dsService != null
+						&& dndService.drop(path, dsService.getActiveDisplay()) ) {
+					width = IMAGE_OPENED;
+					return null;
+				}
 				final IOService ioService = context.getService(IOService.class);
 				final UIService uiService = context.getService(UIService.class);
 				if (ioService != null && uiService != null) {


### PR DESCRIPTION
Hi,

I propose to explicitly trigger the IJ2 DragAndDrop mechanism to allow developers more flexible (and modern) registration of their handlers of drag-and-drop events. I have _empirically_ determined the last resort in the chain of the already established handlers, the last moment before the "universal" `IOService::open()` takes care of the incoming file or folder. Indeed, the `open()` hardly never fails to open whatever is dropped onto the Fiji window.

I also believe the IJ2 mechanism is not triggered anywhere before this IJ1 code, see below the call trace:
![Screenshot_20220202_224340](https://user-images.githubusercontent.com/10509335/152257045-f8b2e64b-5f3e-4216-af3c-b126c9e64a90.png)
(sorry, I took screenshot instead of cut&paste)

Cheers,
Vlado

