### PR TITLE
avoid opening data that was already opened in 3rd party opener

### DIFF
--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -549,7 +549,8 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 					final Object data = ioService.open(path);
 					if (data != null) {
 						width = IMAGE_OPENED;
-						uiService.show(data);
+						if (data != IOService.GOVERNING_APP_STARTED)
+							uiService.show(data);
 						return null;
 					}
 				}


### PR DESCRIPTION
When processing a drag&drop event, the processing [may reach to the stage](https://github.com/fiji/IO/blob/3aa1c1a93abf199766c86384ab5cdb968981b841/src/main/java/HandleExtraFileTypes.java#L541-L560) in which `IOService` is trying to resolve the incoming data/file.

As discussed in scijava-common's PR, sometimes user wants to open the incoming data in own way other than the default `uiService.show()`.

This PR proposes to check the output of the used `IOService` opener for the new `IOService.GOVERNING_APP_STARTED`,
and if present, no reach out to `uiService.show(data)`.