### PR TITLE
Order of drag&drop processing: Bio-Formats vs IOService

### DIFF
--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -487,6 +487,12 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 			return tryPlugIn("org.janelia.it.fiji.plugins.h5j.H5j_Reader", path);
 		}
 
+		// Vladimir Ulman: BigDataViewer's xml -> flag to pass processing beyond Bioformats
+		if (name.endsWith(".xml") && new String(buf).contains("<SpimData version")) {
+			width = BYPASS_BIOFORMATS_TO_IOSERVICE;
+			return null;
+		}
+
 		// ****************** MODIFY HERE ******************
 		// do what ever you have to do to recognise your own file type
 		// and then call appropriate plugin using the above as models

--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -61,6 +61,7 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 
 	static final int IMAGE_OPENED = -1;
 	static final int PLUGIN_NOT_FOUND = -2;
+	static final int BYPASS_BIOFORMATS_TO_IOSERVICE = -3;
 	static final boolean LOCI_PRESENT = checkForLoci();
 
 	private static boolean checkForLoci() {
@@ -517,7 +518,7 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 
 		// try opening the file with Bio-Formats plugin - always check this last!
 		// Do not call Bio-Formats if File>Import>Image Sequence is being used.
-		if (o == null &&
+		if (o == null && width != BYPASS_BIOFORMATS_TO_IOSERVICE &&
 			(IJ.getVersion().compareTo("1.38j") < 0 || !IJ.redirectingErrorMessages()) &&
 			(new File(path).exists()))
 		{


### PR DESCRIPTION
Hi @ctrueden,

motivated solely by the ability to drag&drop BDV's xml files onto Fiji I came up with the proposed *patch*...
The thing is that some of the Bio-Formats plugin/reader (hope I recall it correctly, was doing it yday) picks up on any incoming .xml and I failed to figure out how to tailor it to detect BDV's xml... I anyway thought we might want a more generic solution and provided this extra state `BYPASS_BIOFORMATS_TO_IOSERVICE` that essentially changes the order of processing (in particular, makes `IOService` process dropped file before Bio-Formats; normally the order is the opposite).