### PR TITLE
HandleExtraFileType: reporting after catching Bio-Formats exceptions

### DIFF
--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -521,20 +521,22 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 			(IJ.getVersion().compareTo("1.38j") < 0 || !IJ.redirectingErrorMessages()) &&
 			(new File(path).exists()))
 		{
-			final Object loci = IJ.runPlugIn("loci.plugins.LociImporter", path);
-			if (loci != null) {
-				// plugin exists and was launched
-				try {
-					// check whether plugin was successful
-					final Class<?> c = loci.getClass();
-					final boolean success = c.getField("success").getBoolean(loci);
-					final boolean canceled = c.getField("canceled").getBoolean(loci);
-					if (success || canceled) {
-						width = IMAGE_OPENED;
-						return null;
+			try {
+				final Object loci = IJ.runPlugIn("loci.plugins.LociImporter", path);
+				if (loci != null) {
+					// plugin exists and was launched
+						// check whether plugin was successful
+						final Class<?> c = loci.getClass();
+						final boolean success = c.getField("success").getBoolean(loci);
+						final boolean canceled = c.getField("canceled").getBoolean(loci);
+						if (success || canceled) {
+							width = IMAGE_OPENED;
+							return null;
+						}
 					}
 				}
-				catch (final Exception exc) {}
+			catch (final Exception exc) {
+				if (IJ.debugMode) IJ.handleException(exc);
 			}
 		}
 

--- a/src/main/java/HandleExtraFileTypes.java
+++ b/src/main/java/HandleExtraFileTypes.java
@@ -536,6 +536,8 @@ public class HandleExtraFileTypes extends ImagePlus implements PlugIn {
 					}
 				}
 			catch (final Exception exc) {
+				IJ.log("Error opening the input in LociImporter who says:\n-----\n"
+						+ exc.getMessage() + "\n-----");
 				if (IJ.debugMode) IJ.handleException(exc);
 			}
 		}


### PR DESCRIPTION
Catches and reports all exceptions when trying to open a file with bioformats reader,
and handles them if Fiji is in the debug mode.

See: https://imagesc.zulipchat.com/#narrow/stream/327470-Mastodon/topic/Release.20beta-25/near/306615130